### PR TITLE
add yaml language server with circle schema to enable the contextual documentation from the Circle LS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CircleCI.nvim
 
-A _very_ early stage plugin and Telescope extension, for visualising CircleCI pipelines, jobs and workflows in neovim. Not really ready to be used yet - but it does work. The code is likely to change a lot with breaking changes common. 
+A _very_ early stage plugin and Telescope extension, for visualising CircleCI pipelines, jobs and workflows in neovim. Not really ready to be used yet - but it does work. The code is likely to change a lot with breaking changes common.
 
 This was started during a hack day at TotallyMoney in 2023; I have no previous experience writing Lua or neovim plugins, but I use neovim daily. Contributors welcome, lots to be done! Loosely based on/inspired by the CircleCI vscode plugin. Code quality is awful, mostly due to: being written in ~18 hours during a hack day while not knowing Lua or the Neovim API. Please don't judge me! I have since continued working on it.
 
@@ -32,12 +32,19 @@ There are further config options available for the LSP:
     config = {
       exec_path = "",
       cmd = {}, -- the LSP executable command in list form
-      on_attach = function(client, bufnr) -- function that gets called when the LSP client attaches
+      on_attach = function(client, bufnr), -- function that gets called when the LSP client attaches
+      enable_yaml = true
     }
   }
 ```
 The recommended way to install the language server is using [Mason.nvim](https://github.com/williamboman/mason.nvim). Run `:Mason`, search for circleci-yaml-language-server and press I to install. The plugin will look in the mason packages directory for the LSP executable by default.
 If you want to install it elsewhere (for example on your $PATH), there are two options: either provide the `cmd` option in the `config.lsp` object, in the form of a list of strings with the required flags. You can also provide the `exec_path` - provide the path to the directory where the executable lives and the plugin will add the required flags.
+
+The CircleCI Language Server also supports contextual documentation for Circle concepts like executors, orbs, pipelines, workflows and more. This functionality requires the [Yaml Language Server](https://github.com/redhat-developer/yaml-language-server). This plugin supports this functionality but it's optional to enable - use the `lsp.config.enable_yaml = true` attribute to enable it. Then install the Yaml Language Server - `yarn global add yaml-language-server`. When in your circleci/config.yml file, you should be able to use `lua vim.lsp.buf.hover()` function to show the documentation.
+Alternatively you can do this yourself in your own config using [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#yamlls). To add the CircleCI yaml schema, add this to the schemas object:
+```
+["https://json.schemastore.org/circleciconfig.json"] = "/.circleci/config.yml"
+```
 
 Currently this plugin only officially supports Github as the source control provider for the project on CircleCI. Gitlab and Bitbucket are in the `providerMap` in [`lua/nvim-circleci.lua`](https://github.com/tomoakley/circleci.nvim/blob/main/lua/nvim-circleci.lua), but I am unable to test them. If they don't work, please open an issue, or even better make a pull request with a fix!
 

--- a/lua/nvim-circleci.lua
+++ b/lua/nvim-circleci.lua
@@ -85,7 +85,10 @@ M.setup = function(args)
 
     local lspConfig = args.lsp or { enable = false }
     if lspConfig.enable then
-      require("nvim-circleci.lsp").start(lspConfig.config, repoRoot)
+      require("nvim-circleci.lsp").start("CircleCI Language Server", lspConfig.config, repoRoot)
+      if lspConfig.config.enable_yaml then
+        require("nvim-circleci.lsp").start("Yaml Language Server", lspConfig.config, repoRoot)
+      end
     end
   end
 end

--- a/lua/nvim-circleci/config.lua
+++ b/lua/nvim-circleci/config.lua
@@ -8,6 +8,7 @@ M.config = {
       exec_path = nil,
       on_attach = nil,
       cmd = nil,
+      enable_yaml = false
     }
   }
 }

--- a/lua/nvim-circleci/lsp.lua
+++ b/lua/nvim-circleci/lsp.lua
@@ -5,9 +5,50 @@ local augroup = vim.api.nvim_create_augroup('client_cmds', {clear = true})
 local autocmd = vim.api.nvim_create_autocmd
 local fmt = string.format
 
-M.start = function(userConfig, rootDir)
-  local config = M.config(userConfig, rootDir)
-  local id = vim.lsp.start_client(config.params)
+
+local function getCircleCILanguageServerConfig(userConfig)
+  local packagePath = userConfig.exec_path or (vim.fn.stdpath('data') .. '/mason/packages/circleci-yaml-language-server')
+  local defaultCmd = {packagePath .. '/darwin-arm64-lsp', '-schema='..packagePath..'/schema.json', '--stdio'}
+  return {
+    cmd = { unpack(userConfig.cmd or defaultCmd) },
+    on_attach = function(client, bufnr)
+      vim.bo.omnifunc = 'v:lua.vim.lsp.omnifunc'
+      local user_on_attach = userConfig.on_attach
+      if user_on_attach then
+        user_on_attach(client, bufnr)
+      end
+    end,
+  }
+end
+
+local function getYamlLanguageServerConfig(userConfig)
+  return {
+    cmd = {"yaml-language-server", "--stdio"},
+    on_attach = function(client, bufnr)
+      local user_on_attach = userConfig.on_attach
+      if user_on_attach then
+        user_on_attach(client, bufnr)
+      end
+    end,
+    settings = {
+      yaml = {
+        schemas = {
+          ["https://json.schemastore.org/circleciconfig.json"] = {"/.circleci/config.yml", "/.circleci/config.yaml"}
+        },
+      }
+    },
+  }
+end
+
+
+local getConfigMethodForLS = {
+  ["CircleCI Language Server"] = getCircleCILanguageServerConfig,
+  ["Yaml Language Server"] = getYamlLanguageServerConfig
+}
+
+M.start = function(lsName, userConfig, rootDir)
+  local config = M.config(lsName, userConfig, rootDir)
+  local id = vim.lsp.start_client(config)
   if not id then return end
 
   if vim.v.vim_did_enter == 1 then
@@ -17,46 +58,20 @@ M.start = function(userConfig, rootDir)
   state.autocmd[id] = autocmd('BufEnter', {
     pattern = '*',
     group = augroup,
-    desc = fmt('Attach LSP: %s', "CircleCI Language Server"),
+    desc = fmt('Attach LSP: %s', lsName),
     callback = function()
       M.buf_attach(config, id)
     end
   })
 end
 
-M.config = function(userConfig, rootDir)
-  local packagePath = userConfig.exec_path or (vim.fn.stdpath('data') .. '/mason/packages/circleci-yaml-language-server')
-  local defaultCmd = {packagePath .. '/darwin-arm64-lsp', '-schema='..packagePath..'/schema.json', '--stdio'}
-  local server_opts = {
-    params = {
-      name = 'CircleCI config helper',
-      cmd = { unpack(userConfig.cmd or defaultCmd) },
-      capabilities = vim.lsp.protocol.make_client_capabilities(),
-      on_attach = function(client, bufnr)
-        vim.bo.omnifunc = 'v:lua.vim.lsp.omnifunc'
-        local user_on_attach = userConfig.on_attach
-        if user_on_attach then
-          user_on_attach(client, bufnr)
-        end
-      end,
-      on_init = function(client, results)
-        if results.offsetEncoding then
-          client.offset_encoding = results.offsetEncoding
-        end
-
-        if client.config.settings then
-          client.notify('workspace/didChangeConfiguration', {
-            settings = client.config.settings
-          })
-        end
-      end,
-      on_error = function(code)
-        print("circleci lsp error " .. code)
-      end,
-      root_dir = rootDir,
-    }
-  }
-  server_opts.params.on_exit = M.on_exit
+M.config = function(lsName, userConfig, rootDir)
+  local server_opts = getConfigMethodForLS[lsName](userConfig)
+  server_opts.name = lsName
+  server_opts.root_dir = rootDir
+  server_opts.on_exit = M.on_exit
+  server_opts.on_init = M.on_init
+  server_opts.capabilities = vim.lsp.protocol.make_client_capabilities()
 
   return server_opts
 end
@@ -70,6 +85,18 @@ M.buf_attach = function(config, id)
 
   local bufnr = vim.api.nvim_get_current_buf()
   vim.lsp.buf_attach_client(bufnr, id)
+end
+
+M.on_init = function(client, results)
+  if results.offsetEncoding then
+    client.offset_encoding = results.offsetEncoding
+  end
+
+  if client.config.settings then
+    client.notify('workspace/didChangeConfiguration', {
+      settings = client.config.settings
+    })
+  end
 end
 
 M.on_exit = function(code, signal, client_id)


### PR DESCRIPTION
Circle LS supports contextual documentation for keywords, orbs and more. Added via Yaml LS and the [CircleCI schemastore](https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/circleciconfig.json).

<img width="1497" alt="Screenshot 2024-04-02 at 19 24 01" src="https://github.com/tomoakley/circleci.nvim/assets/782523/1530e249-f7c7-446c-b5c9-489d9532d2ac">

Part of #8.
