### PR TITLE
Complete "open in browser" functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ In your neovim config file, add:
 circleci.setup()
 ```
 
+### LSP
 To enable the [CircleCI YAML Language Server](https://github.com/CircleCI-Public/circleci-yaml-language-server), add some config to the setup call:
 ```
 circleci.setup{
@@ -24,6 +25,7 @@ circleci.setup{
     enable = true
   }
 }
+
 ```
 There are further config options available for the LSP:
 ```
@@ -54,4 +56,11 @@ To show all the projects pipelines from every user, run this command:
 lua require('telescope').extensions.circleci.get_all_pipelines()
 ```
 
-
+To open a pipeline or workflow in a browser, use `<C-o>` while in the picker. To modify this mapping, pass in this config to the `circleci.setup()` method:
+```
+{
+  "mappings" = {
+    "open_in_browser" = "<C-a>" -- pass new mapping here
+  }
+}
+```

--- a/lua/nvim-circleci.lua
+++ b/lua/nvim-circleci.lua
@@ -68,7 +68,7 @@ M.setup = function(args)
   -- you can define your setup function here. Usually configurations can be merged, accepting outside params and
   -- you can also put some validation here for those.
 
-  config.config = args
+  config.mergeConfig(config.config, args)
   -- Usage
   local repoRoot = getTopLevelOfRepo()
   if checkForCircleCIConfig(repoRoot) then

--- a/lua/nvim-circleci.lua
+++ b/lua/nvim-circleci.lua
@@ -77,7 +77,7 @@ M.setup = function(args)
       local projectSlug = formatRemoteOriginToProjectSlug(remoteOriginUrl)
       if projectSlug then
         require("telescope").load_extension("circleci")
-        config.config = { project_slug = projectSlug }
+        config.config.project_slug = projectSlug
       end
     else
       print("Error opening git config file")

--- a/lua/nvim-circleci/config.lua
+++ b/lua/nvim-circleci/config.lua
@@ -2,6 +2,9 @@ local M = {}
 
 M.config = {
   project_slug = '',
+  mappings = {
+    open_in_browser = '<C-o>'
+  },
   lsp = {
     enable = false,
     config = {
@@ -11,5 +14,20 @@ M.config = {
     }
   }
 }
+
+M.mergeConfig = function(defaultConfig, userConfig)
+  for k, v in pairs(userConfig) do
+      if type(v) == "table" then
+          if type(defaultConfig[k] or false) == "table" then
+              M.mergeConfig(defaultConfig[k], v)
+          else
+              defaultConfig[k] = v
+          end
+      else
+          defaultConfig[k] = v
+      end
+  end
+  return defaultConfig
+end
 
 return M

--- a/lua/telescope/_extensions/circleci.lua
+++ b/lua/telescope/_extensions/circleci.lua
@@ -101,12 +101,12 @@ local get_pipelines = function(opts, mineOrAll)
     -- previewer = conf.file_previewer(opts),
     attach_mappings = function(_, map)
       --action_set.select:replace(open_branch_workflows_in_browser)
+      map("i", config.config.mappings['open_in_browser'], open_branch_workflows_in_browser)
       action_set.select:replace(function(prompt_bufnr, type)
         open_preview_buffer(type)(prompt_bufnr)
       end)
-      map("i", "<c-b>", open_branch_workflows_in_browser)
       return true
-      end,
+    end,
     previewer = previewers.new_buffer_previewer{
       title = 'Workflow Preview',
       keep_last_buf = true,

--- a/lua/telescope/_extensions/circleci.lua
+++ b/lua/telescope/_extensions/circleci.lua
@@ -9,6 +9,7 @@ local action_state = require "telescope.actions.state"
 
 local auth = require'nvim-circleci.auth'
 local utils = require'nvim-circleci.utils'
+local config = require'nvim-circleci.config'
 --local previewers = require 'nvim-circleci.telescope.previewers'
 
 local function open_preview_buffer(command)
@@ -33,14 +34,16 @@ local workflowData = {}
 
 local open_branch_workflows_in_browser = function()
   local entry = action_state.get_selected_entry()
-  local url = 'https://app.circleci.com/pipelines'
+  if not workflowData.id then return end
+  local project_slug = config.config['project_slug']
+  local url = 'https://app.circleci.com/pipelines/'..project_slug..'/'..entry.number..'/workflows/'..workflowData['id']
   vim.fn.jobstart({"open", url}, {detach = true})
 end
 
 local createPreview = function(bufnr, entry)
   vim.defer_fn(function()
     local workflow = auth.getWorkflowById(entry.id)
-    workflowData(workflow[1])
+    workflowData = workflow[1]
     for k,v in ipairs(workflow) do
       vim.api.nvim_buf_set_lines(bufnr, 0, k+1, false, {string.format(
         '%s, %s', v["name"], v["status"]

--- a/lua/telescope/_extensions/circleci.lua
+++ b/lua/telescope/_extensions/circleci.lua
@@ -29,14 +29,18 @@ local function open_preview_buffer(command)
   end
 end
 
+local workflowData = {}
+
 local open_branch_workflows_in_browser = function()
-    local entry = action_state.get_selected_entry()
-    print(vim.inspect(entry))
+  local entry = action_state.get_selected_entry()
+  local url = 'https://app.circleci.com/pipelines'
+  vim.fn.jobstart({"open", url}, {detach = true})
 end
 
 local createPreview = function(bufnr, entry)
   vim.defer_fn(function()
     local workflow = auth.getWorkflowById(entry.id)
+    workflowData(workflow[1])
     for k,v in ipairs(workflow) do
       vim.api.nvim_buf_set_lines(bufnr, 0, k+1, false, {string.format(
         '%s, %s', v["name"], v["status"]
@@ -92,13 +96,13 @@ local get_pipelines = function(opts, mineOrAll)
     },
     sorter = conf.generic_sorter(opts),
     -- previewer = conf.file_previewer(opts),
-      attach_mappings = function(_, map)
-        --action_set.select:replace(open_branch_workflows_in_browser)
-        action_set.select:replace(function(prompt_bufnr, type)
-          open_preview_buffer(type)(prompt_bufnr)
-        end)
-        map("i", "<c-b>", open_branch_workflows_in_browser)
-        return true
+    attach_mappings = function(_, map)
+      --action_set.select:replace(open_branch_workflows_in_browser)
+      action_set.select:replace(function(prompt_bufnr, type)
+        open_preview_buffer(type)(prompt_bufnr)
+      end)
+      map("i", "<c-b>", open_branch_workflows_in_browser)
+      return true
       end,
     previewer = previewers.new_buffer_previewer{
       title = 'Workflow Preview',


### PR DESCRIPTION
This comples the "open in browser" functionality. It adds a user-configurable mapping (`<C-o>` rather than `<C-b>` as this is taken by telescope already and required two activations to use). It also merges the default and user config.

Closes #7.