### PR TITLE
add branch and user to telescope ordinal to enable better search

### DIFF
--- a/lua/telescope/_extensions/circleci.lua
+++ b/lua/telescope/_extensions/circleci.lua
@@ -92,7 +92,7 @@ local get_pipelines = function(opts, mineOrAll)
       results = pipelines,
       entry_maker = function(entry)
           entry.value = entry.branch
-          entry.ordinal = tostring(entry.number)
+          entry.ordinal = tostring(entry.number) .. " " .. (entry.branch or "") .. " " .. entry.user
           entry.display = make_display
           return entry
       end,


### PR DESCRIPTION
Adds the branch and user attributes to the telescope ordinal to improve the search.

Closes #12.