### PR TITLE
add setToken and setSelfHostedUrl commands for Circle LSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Alternatively you can do this yourself in your own config using [nvim-lspconfig]
 
 Currently this plugin only officially supports Github as the source control provider for the project on CircleCI. Gitlab and Bitbucket are in the `providerMap` in [`lua/nvim-circleci.lua`](https://github.com/tomoakley/circleci.nvim/blob/main/lua/nvim-circleci.lua), but I am unable to test them. If they don't work, please open an issue, or even better make a pull request with a fix!
 
+If you self-host your own CircleCI infrastructure, you can pass the config variable `selfHostedUrl` to set that.
+
 ## Telescope
 The Telescope extension is only activated by the plugin if the project root has a `.circleci` directory.
 

--- a/lua/nvim-circleci/auth.lua
+++ b/lua/nvim-circleci/auth.lua
@@ -3,16 +3,17 @@ local curl = require "plenary.curl"
 local config = require"nvim-circleci.config"
 
 function auth.get_circle_token()
+  if auth.token then return auth.token end
   local result = vim.fn.system('security find-generic-password -w -a ${USER} -D "environment variable" -s "circleci"')
   return string.gsub(result, '\n', '')
 end
 
-local token = auth.get_circle_token()
+auth.token = auth.get_circle_token()
 
 local function makeRequest(method, url)
   local headers = {
     ['content-type'] = "application/json",
-    ['Circle-Token'] = token
+    ['Circle-Token'] = auth.token
   }
   local opts = {
     url = string.format('https://circleci.com/api/v2/%s', url),

--- a/lua/nvim-circleci/config.lua
+++ b/lua/nvim-circleci/config.lua
@@ -2,6 +2,7 @@ local M = {}
 
 M.config = {
   project_slug = '',
+  selfHostedUrl = nil,
   mappings = {
     open_in_browser = '<C-o>'
   },

--- a/lua/nvim-circleci/lsp.lua
+++ b/lua/nvim-circleci/lsp.lua
@@ -1,5 +1,5 @@
 local auth = require"nvim-circleci.auth"
-local config = require"nvim-circleci.config"
+local configArgs = require"nvim-circleci.config"
 local M = {}
 local state = {autocmd = {}}
 
@@ -25,14 +25,12 @@ local function getCircleCILanguageServerConfig(userConfig)
         command = "setToken",
         arguments = {auth.token}
       }, function(err, result, ctx)
-        print('success ', result, ', error: ', err)
       end)
-      if config.config.selfHostedUrl then
+      if configArgs.config.selfHostedUrl then
         client.request('workspace/executeCommand', {
           command = "setSelfHostedUrl",
-          arguments = {config.config.selfHostedUrl}
+          arguments = {configArgs.config.selfHostedUrl}
         }, function(err, result, ctx)
-          print('success ', result, ', error: ', err)
         end)
       end
     end


### PR DESCRIPTION
This PR sets the Circle user token in the Circle LSP to enable it to get info about private contexts/orbs, and if `selfHostedUrl` is provided in the config, it will set this URL in the LSP.

- Also changed slightly how the auth token works; now stores in memory so that it doesn't have to run the `security` command each time.